### PR TITLE
Circuit state machines

### DIFF
--- a/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/Circuit.kt
+++ b/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/Circuit.kt
@@ -6,6 +6,7 @@ import net.voxelpi.vire.api.circuit.component.Component
 import net.voxelpi.vire.api.circuit.network.Network
 import net.voxelpi.vire.api.circuit.network.NetworkNode
 import net.voxelpi.vire.api.circuit.statemachine.StateMachine
+import net.voxelpi.vire.api.circuit.statemachine.StateMachineInstance
 import net.voxelpi.vire.api.environment.Environment
 import java.util.UUID
 
@@ -37,8 +38,22 @@ interface Circuit {
 
     /**
      * Creates a new component with the given [stateMachine].
+     * The parameters of the state machine instance are configured using the specified [configuration].
      */
-    fun createComponent(stateMachine: StateMachine): Component
+    fun createComponent(
+        stateMachine: StateMachine,
+        configuration: StateMachineInstance.ConfigurationContext.() -> Unit = {},
+    ): Component
+
+    /**
+     * Creates a new component with the given [stateMachine].
+     * The parameters of the state machine instance are configured using the specified [configuration].
+     * Whilst Not all parameters must be specified, only existing parameters may be specified.
+     */
+    fun createComponent(
+        stateMachine: StateMachine,
+        configuration: Map<String, Any?>,
+    ): Component
 
     /**
      * Removes the given [component] from the simulation.

--- a/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/statemachine/StateMachine.kt
+++ b/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/statemachine/StateMachine.kt
@@ -4,6 +4,7 @@ import net.voxelpi.vire.api.Identifier
 import net.voxelpi.vire.api.LogicState
 import net.voxelpi.vire.api.LogicValue
 import net.voxelpi.vire.api.Vire
+import net.voxelpi.vire.api.circuit.Circuit
 import net.voxelpi.vire.api.circuit.statemachine.annotation.StateMachineTemplate
 import kotlin.reflect.KClass
 
@@ -439,6 +440,13 @@ interface StateMachine {
          */
         fun generate(type: KClass<out StateMachineTemplate>): StateMachine {
             return Vire.get().stateMachineFactory.generate(type)
+        }
+
+        /**
+         * Generates a new state machine from the given circuit.
+         */
+        fun createFromCircuit(id: Identifier, circuit: Circuit): StateMachine {
+            return Vire.get().stateMachineFactory.createFromCircuit(id, circuit)
         }
 
         /**

--- a/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/statemachine/StateMachineFactory.kt
+++ b/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/statemachine/StateMachineFactory.kt
@@ -2,6 +2,7 @@ package net.voxelpi.vire.api.circuit.statemachine
 
 import net.voxelpi.vire.api.Identifier
 import net.voxelpi.vire.api.LogicState
+import net.voxelpi.vire.api.circuit.Circuit
 import net.voxelpi.vire.api.circuit.statemachine.annotation.StateMachineTemplate
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -20,6 +21,13 @@ interface StateMachineFactory {
      * Generates a new state machine from the given [type].
      */
     fun generate(type: KClass<out StateMachineTemplate>): StateMachine
+
+    /**
+     * Generates a new state machine from the given circuit.
+     * For every component that is tagged with the [CircuitStateMachine.CIRCUIT_INPUT_TAG] an input variable is generated,
+     * and for every component that is tagged with the [CircuitStateMachine.CIRCUIT_OUTPUT_TAG] an output variable is generated.
+     */
+    fun createFromCircuit(id: Identifier, circuit: Circuit): StateMachine
 
     /**
      * Creates a new input.

--- a/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/statemachine/circuit/CircuitIOStateMachines.kt
+++ b/vire-api/src/main/kotlin/net/voxelpi/vire/api/circuit/statemachine/circuit/CircuitIOStateMachines.kt
@@ -1,0 +1,54 @@
+package net.voxelpi.vire.api.circuit.statemachine.circuit
+
+import net.voxelpi.vire.api.Identifier
+import net.voxelpi.vire.api.LogicState
+import net.voxelpi.vire.api.circuit.statemachine.StateMachine
+import net.voxelpi.vire.api.circuit.statemachine.StateMachineProvider
+import net.voxelpi.vire.api.circuit.statemachine.input
+import net.voxelpi.vire.api.circuit.statemachine.output
+import net.voxelpi.vire.api.circuit.statemachine.parameter
+import net.voxelpi.vire.api.circuit.statemachine.variable
+
+object Input : StateMachineProvider {
+    val name = parameter("name", "input")
+    val value = variable("value", LogicState.EMPTY)
+    val output = output("output")
+
+    /**
+     * Tag for state machines that should act as circuit input when creating circuit-state-machines.
+     */
+    val CIRCUIT_INPUT_TAG = Identifier.parse("vire:circuit_input")
+
+    override val stateMachine = StateMachine.create(Identifier("vire", "input")) {
+        tags += CIRCUIT_INPUT_TAG
+        declare(name)
+        declare(value)
+        declare(output)
+
+        update = { context ->
+            context[output] = context[value]
+        }
+    }
+}
+
+object Output : StateMachineProvider {
+    val name = parameter("name", "output")
+    val value = variable("value", LogicState.EMPTY)
+    val input = input("input")
+
+    /**
+     * Tag for state machines that should act as circuit output when creating circuit-state-machines.
+     */
+    val CIRCUIT_OUTPUT_TAG = Identifier.parse("vire:circuit_output")
+
+    override val stateMachine = StateMachine.create(Identifier("vire", "output")) {
+        tags += CIRCUIT_OUTPUT_TAG
+        declare(name)
+        declare(value)
+        declare(input)
+
+        update = { context ->
+            context[value] = context[input]
+        }
+    }
+}

--- a/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/circuit/VireCircuit.kt
+++ b/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/circuit/VireCircuit.kt
@@ -17,10 +17,12 @@ import net.voxelpi.vire.api.circuit.event.network.node.NetworkNodeDestroyEvent
 import net.voxelpi.vire.api.circuit.network.Network
 import net.voxelpi.vire.api.circuit.network.NetworkNode
 import net.voxelpi.vire.api.circuit.statemachine.StateMachine
+import net.voxelpi.vire.api.circuit.statemachine.StateMachineInstance
 import net.voxelpi.vire.engine.circuit.component.VireComponent
 import net.voxelpi.vire.engine.circuit.network.VireNetwork
 import net.voxelpi.vire.engine.circuit.network.VireNetworkNode
 import net.voxelpi.vire.engine.circuit.statemachine.VireStateMachine
+import net.voxelpi.vire.engine.circuit.statemachine.VireStateMachineInstance
 import net.voxelpi.vire.engine.environment.VireEnvironment
 import java.util.UUID
 
@@ -44,11 +46,22 @@ class VireCircuit(
         return components[uniqueId]
     }
 
-    override fun createComponent(stateMachine: StateMachine): VireComponent {
+    override fun createComponent(
+        stateMachine: StateMachine,
+        configuration: StateMachineInstance.ConfigurationContext.() -> Unit,
+    ): VireComponent {
         require(stateMachine is VireStateMachine)
+        return createComponent(stateMachine.createInstance(configuration))
+    }
 
+    override fun createComponent(stateMachine: StateMachine, configuration: Map<String, Any?>): VireComponent {
+        require(stateMachine is VireStateMachine)
+        return createComponent(stateMachine.createInstance(configuration))
+    }
+
+    private fun createComponent(stateMachineInstance: VireStateMachineInstance): VireComponent {
         // Create the component.
-        val component = VireComponent(this, stateMachine)
+        val component = VireComponent(this, stateMachineInstance)
         components[component.uniqueId] = component
 
         // Fire the event.

--- a/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/circuit/component/VireComponent.kt
+++ b/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/circuit/component/VireComponent.kt
@@ -7,21 +7,22 @@ import net.voxelpi.vire.api.circuit.component.ComponentPortVectorVariable
 import net.voxelpi.vire.api.circuit.event.component.ComponentConfigureEvent
 import net.voxelpi.vire.api.circuit.event.component.port.ComponentPortCreateEvent
 import net.voxelpi.vire.api.circuit.event.component.port.ComponentPortDestroyEvent
+import net.voxelpi.vire.api.circuit.statemachine.StateMachine
 import net.voxelpi.vire.api.circuit.statemachine.StateMachineInput
 import net.voxelpi.vire.api.circuit.statemachine.StateMachineOutput
 import net.voxelpi.vire.engine.circuit.VireCircuit
 import net.voxelpi.vire.engine.circuit.VireCircuitElement
-import net.voxelpi.vire.engine.circuit.statemachine.VireStateMachine
 import net.voxelpi.vire.engine.circuit.statemachine.VireStateMachineInstance
 import java.util.UUID
 
 class VireComponent(
     override val circuit: VireCircuit,
-    override val stateMachine: VireStateMachine,
+    override val stateMachineInstance: VireStateMachineInstance,
     override val uniqueId: UUID = UUID.randomUUID(),
 ) : VireCircuitElement(), Component {
 
-    override val stateMachineInstance: VireStateMachineInstance = stateMachine.createInstance {}
+    override val stateMachine: StateMachine
+        get() = stateMachineInstance.stateMachine
 
     private val ports: MutableMap<UUID, VireComponentPort> = mutableMapOf()
 

--- a/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/circuit/statemachine/VireStateMachineFactory.kt
+++ b/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/circuit/statemachine/VireStateMachineFactory.kt
@@ -374,6 +374,10 @@ class VireStateMachineFactory : StateMachineFactory {
                     val component = inputComponents[name]!!
                     val value = context[input]
                     component.stateMachineInstance[net.voxelpi.vire.api.circuit.statemachine.circuit.Input.value] = value
+
+                    // Push the output to reduce delay by 1 tick.
+                    component.tick()
+                    component.pushOutputs()
                 }
 
                 // Simulate the circuit.
@@ -382,6 +386,10 @@ class VireStateMachineFactory : StateMachineFactory {
                 // Copy the state of all output components in the internal circuit to the corresponding output variables.
                 for ((name, output) in outputs) {
                     val component = outputComponents[name]!!
+
+                    // Pull the input to reduce delay by 1 tick.
+                    component.pullInputs()
+                    component.tick()
                     val value = component.stateMachineInstance[net.voxelpi.vire.api.circuit.statemachine.circuit.Output.value]
                     context[output] = value
                 }

--- a/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/environment/VireEnvironment.kt
+++ b/vire-engine/src/main/kotlin/net/voxelpi/vire/engine/environment/VireEnvironment.kt
@@ -7,6 +7,8 @@ import net.voxelpi.vire.api.Identifier
 import net.voxelpi.vire.api.circuit.Circuit
 import net.voxelpi.vire.api.circuit.library.Library
 import net.voxelpi.vire.api.circuit.statemachine.StateMachine
+import net.voxelpi.vire.api.circuit.statemachine.circuit.Input
+import net.voxelpi.vire.api.circuit.statemachine.circuit.Output
 import net.voxelpi.vire.api.environment.Environment
 import net.voxelpi.vire.engine.circuit.VireCircuit
 import net.voxelpi.vire.engine.circuit.statemachine.VireStateMachine
@@ -28,13 +30,19 @@ class VireEnvironment(
         this.libraries = libraries.associateBy { it.id }
         logger.info { "Loaded ${libraries.size} libraries: ${libraries.joinToString(", ", "[", "]") { it.name }}" }
 
-        // Register state machines
-        val stateMachines = mutableMapOf<Identifier, VireStateMachine>()
+        // Register internal state machines.
+        val stateMachines = mutableMapOf<Identifier, VireStateMachine>(
+            Input.stateMachine.id to Input.stateMachine as VireStateMachine,
+            Output.stateMachine.id to Output.stateMachine as VireStateMachine,
+        )
+
+        // Register library state machines.
         for (library in libraries) {
             stateMachines += library.stateMachines()
                 .map { it as VireStateMachine }
                 .associateBy(StateMachine::id)
         }
+
         this.stateMachines = stateMachines
         logger.info { "Registered ${stateMachines.size} state machines" }
     }

--- a/vire-engine/src/test/kotlin/net/voxelpi/vire/engine/circuit/statemachine/VireCircuitStateMachineTest.kt
+++ b/vire-engine/src/test/kotlin/net/voxelpi/vire/engine/circuit/statemachine/VireCircuitStateMachineTest.kt
@@ -1,0 +1,91 @@
+package net.voxelpi.vire.engine.circuit.statemachine
+
+import net.voxelpi.vire.api.Identifier
+import net.voxelpi.vire.api.LogicState
+import net.voxelpi.vire.api.circuit.statemachine.StateMachine
+import net.voxelpi.vire.api.circuit.statemachine.circuit.Input
+import net.voxelpi.vire.api.circuit.statemachine.circuit.Output
+import net.voxelpi.vire.api.circuit.statemachine.input
+import net.voxelpi.vire.api.circuit.statemachine.output
+import net.voxelpi.vire.engine.VireImplementation
+import net.voxelpi.vire.engine.circuit.VireCircuit
+import net.voxelpi.vire.engine.environment.VireEnvironment
+import net.voxelpi.vire.engine.simulation.VireSimulation
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class VireCircuitStateMachineTest {
+
+    private lateinit var environment: VireEnvironment
+    private lateinit var circuit: VireCircuit
+    private lateinit var simulation: VireSimulation
+
+    @BeforeEach
+    fun setUp() {
+        environment = VireImplementation.createEnvironment(emptyList())
+        circuit = environment.createCircuit()
+        simulation = environment.createSimulation(circuit)
+    }
+
+    @Test
+    fun `test circuit state machines`() {
+        val integratedCircuit = environment.createCircuit()
+
+        val internalInputVariable = input("input")
+        val internalOutputVariable = output("output")
+        val internalStateMachine = StateMachine.create(Identifier("vire-test", "buffer")) {
+            declare(internalInputVariable)
+            declare(internalOutputVariable)
+
+            update = { context ->
+                context[internalOutputVariable] = context[internalInputVariable].booleanState()
+            }
+        }
+
+        val internalComponent = integratedCircuit.createComponent(internalStateMachine)
+        val internalComponentInputPort = internalComponent.createPort(internalInputVariable.variable(0))
+        val internalComponentOutputPort = internalComponent.createPort(internalOutputVariable.variable(0))
+
+        // Create an input component in the integrated circuit.
+        val integratedInputComponent = integratedCircuit.createComponent(Input.stateMachine) {
+            this[Input.name] = "integrated_input"
+        }
+        val integratedInput = integratedInputComponent.createPort(Input.output.variable(0))
+
+        // Create an output component in the integrated circuit.
+        val integratedOutputComponent = integratedCircuit.createComponent(Output.stateMachine) {
+            this[Output.name] = "integrated_output"
+        }
+        val integratedOutput = integratedOutputComponent.createPort(Output.input.variable(0))
+
+        // Connect the internal networks.
+        integratedCircuit.createNetworkNodeConnection(integratedInput.node, internalComponentInputPort.node)
+        integratedCircuit.createNetworkNodeConnection(integratedOutput.node, internalComponentOutputPort.node)
+
+        val stateMachine = StateMachine.createFromCircuit(Identifier.parse("test:internal"), integratedCircuit)
+        require(stateMachine is VireStateMachine)
+        val input = stateMachine.inputs["integrated_input"]!!
+        val output = stateMachine.outputs["integrated_output"]!!
+        val instance = stateMachine.createInstance {}
+
+        instance[input] = LogicState.value(true, 2)
+        instance.initializeOutputs()
+
+        // Component has a delay of 3:
+        // 1. Write the input to the internal network.
+        // 2. Read and Write the value in the internal buffer.
+        // 3. Read the input from the internal network.
+        for (i in 0..<3) {
+            instance.update()
+            println("Step $i:")
+            println(integratedInputComponent.stateMachineInstance[Input.value])
+            println(internalComponent.stateMachineInstance[internalInputVariable])
+            println(internalComponent.stateMachineInstance[internalOutputVariable])
+            println(integratedOutputComponent.stateMachineInstance[Output.value])
+        }
+
+        val result = instance[output]
+        assertEquals(LogicState.value(true, 2), result)
+    }
+}

--- a/vire-engine/src/test/kotlin/net/voxelpi/vire/engine/circuit/statemachine/VireCircuitStateMachineTest.kt
+++ b/vire-engine/src/test/kotlin/net/voxelpi/vire/engine/circuit/statemachine/VireCircuitStateMachineTest.kt
@@ -71,19 +71,7 @@ class VireCircuitStateMachineTest {
 
         instance[input] = LogicState.value(true, 2)
         instance.initializeOutputs()
-
-        // Component has a delay of 3:
-        // 1. Write the input to the internal network.
-        // 2. Read and Write the value in the internal buffer.
-        // 3. Read the input from the internal network.
-        for (i in 0..<3) {
-            instance.update()
-            println("Step $i:")
-            println(integratedInputComponent.stateMachineInstance[Input.value])
-            println(internalComponent.stateMachineInstance[internalInputVariable])
-            println(internalComponent.stateMachineInstance[internalOutputVariable])
-            println(integratedOutputComponent.stateMachineInstance[Output.value])
-        }
+        instance.update()
 
         val result = instance[output]
         assertEquals(LogicState.value(true, 2), result)


### PR DESCRIPTION
This PR adds circuit state machines. These are state machines that wrap an entire circuit so that it can be used for components in other circuits.

The inputs and outputs of the state machine are generated from components that use the new statemachines "vire:circuit_input" and "vire:circuit_output". These state machines are part of the engine and can not be disabled by removing the standard library.